### PR TITLE
Update launch_background.xml

### DIFF
--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
+<!--
+   Splash screen definition using a layer-list.
+   1) A background shape with optional gradient or solid color.
+   2) An optional centered bitmap for a logo or launch image.
+   Customize to suit your design.
+-->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
 
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <!-- Background layer: either a solid color or a gradient shape. -->
+    <item>
+        <shape android:shape="rectangle">
+            <!-- Example gradient. Replace @color/splash_* with your own color resources. -->
+            <gradient
+                android:startColor="@color/splash_start"
+                android:centerColor="@color/splash_center"
+                android:endColor="@color/splash_end"
+                android:angle="90" />
+        </shape>
+    </item>
+
+    <!-- 
+       Optional second layer: a centered image/logo.
+       Uncomment and set your mipmap or drawable resource.
+    -->
+    <!--
+    <item>
         <bitmap
             android:gravity="center"
             android:src="@mipmap/launch_image" />
-    </item> -->
+    </item>
+    -->
+
 </layer-list>


### PR DESCRIPTION
Below is an enhanced version of your layer-list XML for an Android launch splash screen. This example includes optional gradient and image items, with clear comments about how to customize them. Adjust the color or image references as needed for your app:

Explanation & Tips
Gradient vs. Solid Background

If you prefer a solid color, replace the <gradient> section with <solid android:color="@color/splash_background" /> inside the <shape> element. Center Image

To show a logo or branding image in the center, uncomment <item> with <bitmap> and reference your own drawable or mipmap resource (@drawable/... or @mipmap/...). Angles and Colors

android:angle="90" creates a top-to-bottom gradient. Adjust or remove for alternative directions. Ensure you define any color resources in your colors.xml. Minimal Setup

For the simplest splash, remove the shape layer and keep only android:drawable="?android:colorBackground" or a single solid element. Comments

Use XML comments (<!-- -->) to clearly label optional sections or instruct team members where to customize.